### PR TITLE
キャラクターシートの見た目を修正

### DIFF
--- a/css/dnd5ejp.css
+++ b/css/dnd5ejp.css
@@ -62,3 +62,8 @@ section.ability-scores.optional-ability-0{
 .item-detail.item-target {
     font-size: 90%;
 }
+
+.dnd5e2 .pills .pill{
+    align-items: center;
+}
+


### PR DESCRIPTION
新シート上のpillにおいて，縦方向の中央揃えを追加
日本語と数字混じりになっているときの見た目を向上しました

### before
![Screen Shot 2025-01-27 at 18 00 03](https://github.com/user-attachments/assets/75bb7473-a3c5-46d7-8c96-d4a09660fbb9)

### after
![Screen Shot 2025-01-27 at 17 59 05](https://github.com/user-attachments/assets/9d174d01-8827-43fe-8b6a-9e794482b574)
