### PR TITLE
Babele 2.6.0に対応

### DIFF
--- a/babele-register.js
+++ b/babele-register.js
@@ -171,17 +171,17 @@ function parseSenses(sensesText) {
 // 	return damage;
 // }
 
-Hooks.once('init', () => {
+Hooks.once('babele.init', (babele) => {
 
 	if(typeof Babele !== 'undefined') {
 
-		Babele.get().register({
+		babele.register({
 			module: 'dnd5eja',
 			lang: 'ja',
 			dir: 'compendium'
 		});
 
-		Babele.get().registerConverters({
+		babele.registerConverters({
 			dndpages(pages, translations) {
 				return pages.map((data) => {
 					if (!translations) {

--- a/module.json
+++ b/module.json
@@ -4,7 +4,6 @@
   "description": "D&D5版システム用(v4.2.0+)の翻訳Modです。SRDの翻訳も含んでいます。このモッドを使用するには必ずモッドを適用してから言語を変更してください。このモッドの正式サポートシートはTidy5e-sheetです",
   "version": "This is auto replaced",
   "library": "false",
-  "manifestPlusVersion": "1.2.0",
   "compatibility": {
     "minimum": 12,
     "verified": 12,
@@ -22,7 +21,9 @@
       {
         "id": "dnd5e",
         "type": "system",
-        "compatibility": {}
+        "compatibility": {
+          "verified": "4.2.2"
+        }
       }
     ],
     "requires": [
@@ -34,7 +35,9 @@
       {
         "id": "babele",
         "type": "module",
-        "compatibility": {}
+        "compatibility": {
+          "verified": "2.6.0"
+        }
       },
       {
         "id": "lib-wrapper",


### PR DESCRIPTION
- Babele 2.6.0でのAPI変更により辞典の翻訳がされない問題を修正
- module.jsonを更新