### PR TITLE
Align maintenance/5.3 with official dnd5e release-5.3.3.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,7 +4,12 @@
 * **翻訳ファイル提供者**: [Brother Sharp, Asami, touge]
 * **ベーシックルール整備協力者**: [TAKUMI]
 * **SRD整備訳協力者**: [SIM_KAZ, TAKUMI, のらせす, コーラ, うどんみ, くろたる, アイリッシュ, なる, kenken, しきちきん, takagi, SikaZika, Jean.N, 弌鳥トリィ, B03, Corsha, SIM]
-* **対応dnd5eバージョン**: 4.2.0+
+* **対応 dnd5e バージョン**: **5.3.0〜5.3.3**（Stable `release-5.3.3` 追従）
+* **対応 Foundry VTT**: **13〜14**（minimum 13 / verified 14）
+
+> このブランチ（`maintenance/5.3`）は **dnd5e 5.3.x / Foundry V13–14** 向けのメンテ線です。  
+> **いまの `master` は当面 5.3 相当のまま**です。**dnd5e 6.0 / Foundry 14.359+** 向けは作業ブランチ `feature/dnd5e-6.0` を利用してください（将来 `master` へマージ予定）。  
+> 検証ピン: [`docs/dnd5e-pin-5.3.txt`](docs/dnd5e-pin-5.3.txt)
 
 ＊現在は2024年版の対応を暫定的に行っています。下の説明が完成するまで時間がかかります。
 使用はできますが、不自然な翻訳に気づきましたら教えて下さい。
@@ -13,10 +18,13 @@
 
 以下のリンクをモッドとしてインストールしてください。
 
-* リンク： https://raw.githubusercontent.com/BrotherSharper/dnd5eja/master/module.json
+* 本線（master・当面 5.3 相当）: https://raw.githubusercontent.com/BrotherSharper/dnd5eja/master/module.json
+* 5.3 メンテ線（upstream）: https://raw.githubusercontent.com/BrotherSharper/dnd5eja/maintenance/5.3/module.json
+* 5.3 メンテ線（fork・upstream 反映前の開発用）: https://raw.githubusercontent.com/kenken-trpg/dnd5eja/maintenance/5.3/module.json
+* 6.0 作業線（fork）: https://raw.githubusercontent.com/kenken-trpg/dnd5eja/feature/dnd5e-6.0/module.json
 
 ### 内容
-D&D5版システム用の翻訳ファイルよび辞典が追加されます。ベーシックルール（整備：TAKUMIさん）およびSRD（整備：オンセ工房サーバのみなさん）の辞典も中に含まれています。
+D&D5版システム用の翻訳ファイルおよび辞典が追加されます。ベーシックルール（整備：TAKUMIさん）およびSRD（整備：オンセ工房サーバのみなさん）の辞典も中に含まれています。
 さらに、D&D2024をFVTTで購入した方はフリールールのデータも日本語で利用できるようになります。
 
 #### SRD

--- a/docs/dnd5e-pin-5.3.txt
+++ b/docs/dnd5e-pin-5.3.txt
@@ -1,0 +1,3 @@
+965ad2d0cf5d063dac675ba078b5bd3c3c0dd449
+965ad2d0c 2026-05-07 Update system.json for 5.3.3 release
+tag: release-5.3.3

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -2277,7 +2277,7 @@
   }
 },
 "DND5E.EffectsApplyTokens": "選択したコマに適用",
-"DND5E.EffectApplyWarning": "所有権限を持っていないコマに効果を適用できません。",
+"DND5E.EffectApplyWarningConcentration": "他のキャラクターが集中している効果を適用するには、GM 権限が必要です。",
 "DND5E.EffectApplyWarningOwnership": "自分が所有していないコマに効果を適用することはできません。",
 "DND5E.EffectsSearch": "効果を検索",
 
@@ -3095,7 +3095,7 @@
     "other": "{number} ヒット･ポイント"
   },
   "DT": {
-    "Abbr": "DT"
+    "abbr": "DT"
   },
   "Other": {
     "label": "その他オプション"
@@ -6045,7 +6045,7 @@
 },
 
 "SOURCE.BOOK.FreeRules": "フリールール",
-"SOURCE.BOOK.SRD": "System Reference Document 5.1",
+"SOURCE.BOOK.SRD51": "システム・リファレンス・ドキュメント 5.1",
 "SOURCE.BOOK.SRD52": "System Reference Document 5.2",
 "SIDEBAR.SortModePriority": "優先順でソートする"
 }

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "dnd5eja",
   "title": "日本語化（DnD5版）",
-  "description": "D&D5版システム用(v5.3.0+)の翻訳Modです。SRDの翻訳も含んでいます。このモッドを使用するには必ずモッドを適用してから言語を変更してください。",
+  "description": "D&D5版システム用(dnd5e v5.3.0〜5.3.3 / Foundry VTT v13–14)の翻訳Modです。SRDの翻訳も含んでいます。このモッドを使用するには必ずモッドを適用してから言語を変更してください。",
   "version": "This is auto replaced",
   "library": "false",
   "compatibility": {


### PR DESCRIPTION
Sync the three remaining ja.json keys, pin Stable release-5.3.3, and document the 5.3 maintenance track with accurate install URLs.